### PR TITLE
Add ModelSpec.load_image

### DIFF
--- a/ml_tools/model_spec.py
+++ b/ml_tools/model_spec.py
@@ -5,6 +5,8 @@ from keras.applications.vgg16 import VGG16, preprocess_input as vgg16_preprocess
 from keras.applications.vgg19 import VGG19, preprocess_input as vgg19_preprocess_input
 from keras.applications.resnet50 import ResNet50, preprocess_input as resnet50_preprocess_input
 
+from .utils import load_image
+
 
 MODEL_SPECS = {
     'inception_v3': {
@@ -47,6 +49,9 @@ class ModelSpec(object):
         self.klass = klass
         self.target_size = target_size
         self.preprocess_input = preprocess_input
+
+    def load_image(self, path):
+        return load_image(path, self.target_size, self.preprocess_input)
 
 
 def get_model_spec(name):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='ml-tools',
-    version='0.0.2',
+    version='0.0.4',
     description='Tools for common machine learning tasks using Tensorflow and Keras.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 import csv
-import codecs
 import requests
 
 from tempfile import NamedTemporaryFile

--- a/tests/test_model_spec.py
+++ b/tests/test_model_spec.py
@@ -1,39 +1,17 @@
 from ml_tools import get_model_spec
+from ml_tools.model_spec import MODEL_SPECS
+
+
+def assert_valid_model_spec(model_spec_name):
+    spec = get_model_spec(model_spec_name)
+    assert spec is not None
+    assert len(spec.target_size) == 3
+    assert spec.klass is not None
+    assert callable(spec.preprocess_input)
+    image_data = spec.load_image('tests/fixtures/files/cat.jpg')
+    assert image_data.any()
 
 
 def test_get_model_spec():
-    spec = get_model_spec('mobilenet_v1')
-    assert spec is not None
-    assert spec.target_size == (224, 224, 3)
-    assert spec.klass is not None
-    assert callable(spec.preprocess_input)
-
-    spec = get_model_spec('inception_v3')
-    assert spec is not None
-    assert spec.target_size == (299, 299, 3)
-    assert spec.klass is not None
-    assert callable(spec.preprocess_input)
-
-    spec = get_model_spec('xception')
-    assert spec is not None
-    assert spec.target_size == (299, 299, 3)
-    assert spec.klass is not None
-    assert callable(spec.preprocess_input)
-
-    spec = get_model_spec('resnet50')
-    assert spec is not None
-    assert spec.target_size == (224, 224, 3)
-    assert spec.klass is not None
-    assert callable(spec.preprocess_input)
-
-    spec = get_model_spec('vgg16')
-    assert spec is not None
-    assert spec.target_size == (224, 224, 3)
-    assert spec.klass is not None
-    assert callable(spec.preprocess_input)
-
-    spec = get_model_spec('vgg19')
-    assert spec is not None
-    assert spec.target_size == (224, 224, 3)
-    assert spec.klass is not None
-    assert callable(spec.preprocess_input)
+    for spec_name in MODEL_SPECS.keys():
+        assert_valid_model_spec(spec_name)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import os
 
 from ml_tools import load_image, get_model_spec, list_files
-from ml_tools.model_spec import MODEL_SPECS 
+from ml_tools.model_spec import MODEL_SPECS
 
 
 def touch(path):
@@ -13,8 +13,8 @@ def test_load_image():
     for spec_name in MODEL_SPECS.keys():
         model_spec = get_model_spec(spec_name)
         image_data = load_image('tests/fixtures/files/cat.jpg',
-                                 model_spec.target_size,
-                                 preprocess_input=model_spec.preprocess_input)
+                                model_spec.target_size,
+                                preprocess_input=model_spec.preprocess_input)
         assert image_data.any()
 
 


### PR DESCRIPTION
While working on some downstream code, I've noticed that I really just want to use `load_image` from the context of the `ModelSpec`, so this adds support for that.